### PR TITLE
fix: Remove prefilled demo data and localStorage loading on app start

### DIFF
--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -15,9 +15,7 @@ export default function Home() {
     <div className="flex items-center justify-center min-h-screen">
       <div className="text-center">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600 mx-auto"></div>
-        <p className="mt-4 text-gray-600">
-          Redirecting to Venture Dossier...
-        </p>
+        <p className="mt-4 text-gray-600">Redirecting to Venture Dossier...</p>
       </div>
     </div>
   );

--- a/apps/frontend/app/workspaces/[wsId]/dossier/elevator/page.tsx
+++ b/apps/frontend/app/workspaces/[wsId]/dossier/elevator/page.tsx
@@ -13,33 +13,35 @@ if (typeof window !== "undefined") {
   // Throttle history API calls to prevent excessive usage
   if (!(window as any).__HISTORY_THROTTLED__) {
     (window as any).__HISTORY_THROTTLED__ = true;
-    
+
     const originalReplaceState = window.history.replaceState;
     let replaceCount = 0;
     let lastReplaceTime = 0;
-    
+
     window.history.replaceState = function (...args) {
       const now = Date.now();
-      
+
       // Reset counter every 10 seconds
       if (now - lastReplaceTime > 10000) {
         replaceCount = 0;
       }
-      
+
       replaceCount++;
-      
+
       // Allow reasonable number of calls (10 per 10 seconds)
       if (replaceCount > 10) {
         if (replaceCount === 11) {
-          console.warn("[THROTTLED] Excessive replaceState calls - throttling active");
+          console.warn(
+            "[THROTTLED] Excessive replaceState calls - throttling active",
+          );
         }
         return; // Throttle but don't completely block
       }
-      
+
       lastReplaceTime = now;
       return originalReplaceState.apply(this, args);
     };
-    
+
     console.log("✅ History API throttling enabled (10 calls/10s limit)");
   }
 }
@@ -400,7 +402,7 @@ function ElevatorPageComponent({ params }: { params: { wsId: string } }) {
 
     const initializeData = async () => {
       await checkBackendConfig();
-      
+
       // Start with clean state - don't load cached data on app start
       // User should explicitly start a new generation
     };

--- a/apps/frontend/app/workspaces/[wsId]/dossier/elevator/page.tsx
+++ b/apps/frontend/app/workspaces/[wsId]/dossier/elevator/page.tsx
@@ -337,10 +337,8 @@ function ProgressBar({ progress }: { progress: number }) {
 function ElevatorPageComponent({ params }: { params: { wsId: string } }) {
   const { throttledReplace } = useThrottledRouter();
 
-  const [title, setTitle] = useState("HappyNest");
-  const [pitch, setPitch] = useState(
-    "HappyNest ist das digitale Zuhause für moderne Familien...",
-  );
+  const [title, setTitle] = useState("");
+  const [pitch, setPitch] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [dryRunWarning, setDryRunWarning] = useState(false);
 
@@ -402,23 +400,9 @@ function ElevatorPageComponent({ params }: { params: { wsId: string } }) {
 
     const initializeData = async () => {
       await checkBackendConfig();
-
-      // Load last dossier from localStorage
-      try {
-        const stored = localStorage.getItem("last_dossier");
-        if (stored && mounted) {
-          const parsed = JSON.parse(stored);
-          setDossier(parsed);
-          // Mark existing sections as done
-          const newSecState: any = {};
-          Object.keys(parsed.sections || {}).forEach((key) => {
-            newSecState[key] = "done";
-          });
-          setSecState(newSecState);
-        }
-      } catch (e) {
-        console.warn("Failed to load last dossier:", e);
-      }
+      
+      // Start with clean state - don't load cached data on app start
+      // User should explicitly start a new generation
     };
 
     initializeData();

--- a/apps/frontend/middleware.ts
+++ b/apps/frontend/middleware.ts
@@ -3,12 +3,12 @@ import type { NextRequest } from "next/server";
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
-  
+
   // Allow dossier routes to pass through without redirect
-  if (pathname.includes('/dossier/')) {
+  if (pathname.includes("/dossier/")) {
     return NextResponse.next();
   }
-  
+
   // Redirect other workspace routes to auto
   return NextResponse.redirect(
     new URL(`/auto${request.nextUrl.search}`, request.url),


### PR DESCRIPTION
This PR fixes the frontend initialization issue by:

- Removing prefilled demo data ('HappyNest' title and pitch)
- Removing localStorage loading of cached dossier data on app start
- App now starts with clean state, requiring explicit user action to generate content
- Fixes the issue where cached data would appear automatically without user interaction

**Changes:**
- Updated  to start with empty state
- Removed localStorage initialization logic from useEffect
- Minor formatting fixes from prettier

**Testing:**
- App now starts with empty input fields
- No cached content is loaded automatically
- User must enter data and click generate to create dossier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Throttled saving of dossier data to improve performance and stability.
  - Ensured final URL updates reliably on job completion.

- Refactor
  - Elevator page now starts with empty title and pitch (no auto-loaded previous dossier).
  - Reduced caching for a cleaner, more predictable start.

- Style
  - Minor formatting updates on the redirect page and middleware; no behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->