### PR TITLE
⏱️ Fix LLM timeout - increase from 25s to 60s

### DIFF
--- a/apps/backend/src/v2/pipeline/StepProcessor.ts
+++ b/apps/backend/src/v2/pipeline/StepProcessor.ts
@@ -235,7 +235,7 @@ export class StepProcessor {
     );
     const response = await this.executeWithTimeout(
       () => chatComplete(prompt, { model, temperature: 0.1 }),
-      25000, // 25 second timeout per call
+      60000, // 60 second timeout per call for complex steps
       `${step.id}-step`,
     );
 
@@ -372,7 +372,7 @@ export class StepProcessor {
     );
     const response = await this.executeWithTimeout(
       () => chatComplete(prompt, { model, temperature: 0.1 }),
-      25000, // 25 second timeout per call
+      60000, // 60 second timeout per call for complex phases
       `${step.id}-${phaseName}`,
     );
 
@@ -462,7 +462,7 @@ export class StepProcessor {
     );
     const response = await this.executeWithTimeout(
       () => chatComplete(prompt, { model, temperature: 0.1 }),
-      25000, // 25 second timeout per call
+      60000, // 60 second timeout per call for complex single-phase steps
       `${step.id}-single`,
     );
 


### PR DESCRIPTION
## Problem
Market step and other complex LLM calls are timing out after 25 seconds:
```
"error": "Step market failed: LLM call timed out after 25000ms"
```

This is blocking the pipeline completion.

## Solution  
- **Increase timeout from 25s → 60s** for all LLM calls
- Affects all 3 execution paths:
  - Single-phase steps  
  - Phase-split steps (market, financial_plan, gtm)
  - Fallback single-phase execution

## Testing
- Will resolve the timeout errors we're seeing in production
- GPT-4 complex market analyses need more time than 25s
- 60s provides sufficient buffer while still catching real hangs

## Impact
- ✅ Fixes current timeout failures
- ✅ No breaking changes
- ✅ Retry logic still intact (2 retries + exponential backoff)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced premature timeouts during complex processing by extending AI operation timeouts to 60 seconds, resulting in fewer failed runs and more consistent results.
* **Chores**
  * Standardized timeout settings across related operations for consistency and improved reliability, aligning behavior in multi-phase and single-phase flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->